### PR TITLE
fix ameoba separation

### DIFF
--- a/players/g4_player.py
+++ b/players/g4_player.py
@@ -452,6 +452,29 @@ class BucketAttack(Strategy):
     #             cell[1] -= 1
     #     return target_cells
 
+    def _get_rectangle_target(self, size: int, cog: cell, xmax: int) -> list[cell]:
+        _, y_cog = cog
+        wall_length, orphans=int(size/4),size%4
+        upper=y_cog+wall_length
+        lower=y_cog-wall_length
+
+        inner_wall_cell_ys = self._spread_vertically(
+            y_cog,
+            upper,
+            lower+orphans
+        )
+        outer_wall_cell_ys = self._spread_vertically(
+            y_cog,
+            upper,
+            lower
+        )
+        wall_cells = (
+                [(xmax % 100, y % 100) for y in inner_wall_cell_ys] +
+                [((xmax + 1) % 100, y % 100) for y in outer_wall_cell_ys]
+        )
+
+        return wall_cells
+
     def _get_cog(self, curr_state: AmoebaState) -> tuple[int, int]:
         """Compute center of gravity of current Ameoba."""
         ameoba_cells = np.array(list(zip(*np.where(curr_state.amoeba_map == State.ameoba.value))))
@@ -543,6 +566,11 @@ class BucketAttack(Strategy):
             mem  = mem[:-5] + f'{self.shifted:b}' + mem[-4:]
         target_cells = self._get_target_cells(size, cog, arm_xval)
         memory = int(mem,2)
+
+        normal_retract, _,_=self._reshape(state, memory, set(target_cells))
+        if len(normal_retract)==0:
+            target_cells = self._get_rectangle_target(size, cog, arm_xval)
+
         return self._reshape(state, memory, set(target_cells))
 
 

--- a/players/g4_player.py
+++ b/players/g4_player.py
@@ -57,71 +57,59 @@ def visualize_reshape(
     
     fig, (ax1, ax2) = debug_fig
 
+    # marker sizes
+    size_s = (mpl.rcParams['lines.markersize'] + 1.5) ** 2
+    size_m = (mpl.rcParams['lines.markersize'] + 2.5) ** 2
+    size_l = (mpl.rcParams['lines.markersize'] + 4) ** 2
+
     # common: ameoba & target
-    for x, y in target:
-        ax1.plot(x, y, 'r.')
-        ax2.plot(x, y, 'r.')
+    for ax in [ax1, ax2]:
+        ax.plot(*list(zip(*target)), 'r.', label='target')
+        ax.plot(*list(zip(*ameoba)), 'g.', label='ameoba')
 
-    for x, y in ameoba:
-        ax1.plot(x, y, 'g.')
-        ax2.plot(x, y, 'g.')
+    def scatter(ax: plt.Axes, pts: list[cell], **kwargs) -> None:
+        if len(pts) == 0:
+            return
 
-    # subplot 1: occupiable & retractable
-    for x, y in occupiable:
-        size = (mpl.rcParams['lines.markersize'] + 1.5) ** 2
-        ax1.scatter(x, y, facecolors='none', edgecolors='tab:purple', s=size)
-
-    for x, y in retractable:
-        size = (mpl.rcParams['lines.markersize'] + 4) ** 2
-        ax1.scatter(x, y, facecolors='none', edgecolors='forestgreen', marker='s', s=size)
-
-    # subplot 2: retract & extend & bacteria
-    for x, y in retract:
-        size = (mpl.rcParams['lines.markersize'] + 4) ** 2
-        ax2.scatter(x, y, facecolors='none', edgecolors='forestgreen', marker='s', s=size)
-
-    for x, y in extend:
-        size = (mpl.rcParams['lines.markersize'] + 1.5) ** 2
-        ax2.scatter(x, y, facecolors='none', edgecolors='tab:purple', s=size)
-
-    for x, y in bacteria:
-        size = (mpl.rcParams['lines.markersize'] + 2.5) ** 2
-        ax2.scatter(x, y, facecolors='none', edgecolors='orange', marker='s', s=size)
+        ax.scatter(*list(zip(*pts)), **kwargs)
 
 
-    # markers
-    mlines = mpl.lines
-    red_dot = mlines.Line2D(
-        [], [], color='g', marker='.', linestyle='None', markersize=5, label='ameoba')
-    green_dot = mlines.Line2D(
-        [], [], color='r', marker='.', linestyle='None', markersize=5, label='target')
-
-    purpule_circle = mlines.Line2D(
-        [], [], color='tab:purple', marker='o', linestyle='None',
-        markerfacecolor='none', markersize=5, label='occupiable')
-    green_square = mlines.Line2D(
-        [], [], color='forestgreen', marker='s', linestyle='None',
-        markerfacecolor='none', markersize=5, label='retractable'
+    # subplot 1: occupiable, retractable
+    scatter(
+        ax1, occupiable, label='occupiable',
+        facecolors='none', edgecolors='tab:purple', s=size_s
+    )
+    scatter(
+        ax1, retractable, label='retractable',
+        facecolors='none', edgecolors='forestgreen', marker='s', s=size_l
     )
 
-    green_square2 = mlines.Line2D(
-        [], [], color='forestgreen', marker='s', linestyle='None',
-        markerfacecolor='none', markersize=5, label='retract')
-    purpule_circle2 = mlines.Line2D(
-        [], [], color='tab:purple', marker='o', linestyle='None',
-        markerfacecolor='none', markersize=5, label='extend')
-    orange_triangle2 = mlines.Line2D(
-        [], [], color='orange', marker='s', linestyle='None',
-        markerfacecolor='none', markersize=5, label='bacteria')
+    # subplot 2: retract, extend, bacteria
+    scatter(
+        ax2, retract, label='retract',
+        facecolors='none', edgecolors='forestgreen', marker='s', s=size_l
+    )
+    scatter(
+        ax2, extend, label='extend',
+        facecolors='none', edgecolors='tab:purple', s=size_s
+    )
+    scatter(
+        ax2, bacteria, label='bacteria',
+        facecolors='none', edgecolors='orange', marker='s', s=size_m
+    )
 
-    # plotting
+    # legend
     ax1.legend(
-        handles=[red_dot, green_dot, purpule_circle, green_square],
-        loc='upper center', bbox_to_anchor=(0.5, 1.1), ncol=4, fancybox=True, shadow=True)
+        loc='upper center', bbox_to_anchor=(0.5, 1.1),
+        ncol=4, fancybox=True, shadow=True
+    )
     ax2.legend(
-        handles=[red_dot, green_dot, purpule_circle2, green_square2, orange_triangle2],
-        loc='upper center', bbox_to_anchor=(0.5, 1.1), ncol=5, fancybox=True, shadow=True)
+        loc='upper center', bbox_to_anchor=(0.5, 1.1),
+        ncol=5, fancybox=True, shadow=True
+    )
     fig.tight_layout()
+
+    # switch back to figure 1: ameoba simulator
     plt.figure(1)
 
 


### PR DESCRIPTION
# Description

This PR fixed the ameoba separation bug observed in class. Please see the figure below for why this bug occured and how it's addressed : )

<img width="1110" alt="image" src="https://user-images.githubusercontent.com/25857014/204594747-74c83e0a-8849-4d3c-8bfe-b26f6b530538.png">

# How has this been tested

- low metaolism:

```shell
python3 main.py -p 4 -A 5 -d 0.2 -m 0.25
```
https://user-images.githubusercontent.com/25857014/204594967-c8a6095f-b488-4edf-8f9e-e8fc3e7b5004.mp4


- minimum metabolism: can only move one cell at first ($\textnormal{ameoba size} \times \textnormal{metabolism} = 1$)

```shell
python3 main.py -p 4 -A 5 -d 0.2 -m 0.04
```

https://user-images.githubusercontent.com/25857014/204596348-2fd3612b-d618-4cb5-ac6e-c64d9cca599d.mp4